### PR TITLE
Draft@rules

### DIFF
--- a/Rules/Rules.md
+++ b/Rules/Rules.md
@@ -743,7 +743,10 @@
 
     1.  At a general meeting, each question, matter or resolution, other than a
         special resolution, must be decided by a majority (50%) of votes of the
-        members present.
+        members present. Both "for" and "against" vote tallies must be recorded
+        in the minutes. Any discrepancies with the recorded numbers for total
+        members present is taken to mean "abstain" vote/s (or users who arrived
+        or departed during the meeting) and do not count toward any vote tally.
     2.  Each member present and eligible to vote is entitled to 1 vote only and,
         if the votes are equal, the chairperson has a casting vote as well as a
         primary vote.
@@ -756,6 +759,8 @@
         conduct the secret ballot in the way the chairperson decides.
     7.  The result of a secret ballot as declared by the chairperson is taken to
         be a resolution of the meeting at which the ballot was held.
+    8.  Any member who abstains in any vote is considered to not be present for
+        that vote, and their vote does not count toward either side.
 
 40. #### Special general meeting
 


### PR DESCRIPTION
**DO NOT MERGE** _This PR is for discussion only_

This PR is for discussing the changes buzz implemented according to this document: https://docs.google.com/document/d/11MYURWjyizebwP47KwD-x9UJ-kZHucu1sox8avEZslE/edit

The hope is that this format will make changes clearer to track and discuss.
### Notes
#### From Buzz
- ~~maximum term is 2 years not 3~~
- ~~tenants/conflict of interest may not hold exec position~~
- ~~possibility of having an exec-lite, privy to exec comms but non voting~~ no need to formalise, exec can transfer powers
- ~~membership cannot go into arrears~~
- ~~revocation clause for dgr status~~ we cannot be a charity due to org aims, hence cannot be dgr.
- ~~general meeting quorum fixed number~~ current rules are fine
- ~~13.2 tracking end of membership~~ clarified by saying 'if available'
- ~~executive now has 2 more roles, vice and patron~~
- ~~vote to remove no subcommittee clause all in favour~~ while this was voted in we are wary to just remove it, no action being taken
- ~~must be approved are problem words (josh note: we dont have these words anymore, what was that referencing?)~~
### From Josh
- ~~Secretary has specific rules around removal. Other executive members should have this also.~~
- ~~English requirement for executive eligability? [TOEIC](http://en.wikipedia.org/wiki/TOEIC) or [IELTS](http://en.wikipedia.org/wiki/IELTS)~~
- Apprenticing system for exec eligability?
- ~~Clarifying exactly what "presence" means, in the actual places where its stated rather than coopting meaning from the appendix. referencing 37.2 may be enough~~
- ~~19.4 : Ballot lists in alphabetic order is a leading vote, ballot order should be randomised (preferably for each card)~~
- ~~19.2 : requirements for eligibility~~
- ~~20.3 : Is this requirement too taxing at our size?~~ no, is currently fine
- ~~23.8 : conflict of interest already built in?~~
- ~~27   : We voted to strike this rule, can it be struck safely or should it be replaced with rules concerning subcommitties?~~
- ~~35   : This seems to disallow members calling general meetings and should probably be updated. 39 seems to allow member requests, but if the secretary/president bucks up and says no or doesnt do their job? 39 does not allow single members to call meetings.~~
- ~~43.2 : this could be clarified as the cheif executive being fair trading~~
- ~~45.8 : petty cash is totally not how we do things is it? whats going on there.~~
- ~~7.2  : This rule is truncated~~
- ~~8.+  : Executive may discount specifically for events/promotions (this was voted in in my tenure, havent tried to locate meeting notes just yet)~~
- ~~45.6 : redacted?~~

More thoughts:
- ~~Locking down vice and patron roles. ie vice is _always_ outgoing president. patron must be oldest available and willing member (having held exec?) or somesuch.~~
- ~~We need to look at making it much, much easier and less stressful on the group to remove bad people. We spend far to much time paralysed by this. issue cards for bad behaviour, then get out. People currently see red cards as 'get out' (because noone reads policy). I suggest then, overall, changing dispute to yellow, orange, red where orange=old red, and red is 'leave the group' to aid the "too confronting" issue. And amending the rules to make a card history grounds for removal, and no appeal process. ie prove bad behaviour, then get out.~~ Dispute policy aside, we've shortened the periods in the hope that this will aid things.
## Causes

This probably needs to be written into the rules as it changes the procedure as to how we can spend money. Ie its just not a bylaw.

Phwoar, wall of text. Hope this works as a good way of building the best next version of our rules.
